### PR TITLE
Added the contract defintion to annoncer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,26 @@ plugins:
   ...
 ```  
 ## Usage  
+### Configuration
 In the `serverless.yml` specify a custom parameter for the announcer:  
 ```
 custom:
   - announcer:
+      # required:
       hook: <your POST webhook>
-```    
+      # optional:
+      contract:   
+        /{function name}: <your contract> 
+```     
+**Hook**:  
+The `hook` must be an accessible `POST` url accepting json input.
+**Contract**:  
+The `contract` is an optional paramter. 
+If specified must be mapped to function name.
+Can be specified in any form. 
+It will be passed along in the body same way as was specified.   
+  
+### Announce Body
 The body that is sent from the announcer is:  
 ```
 [
@@ -31,12 +45,14 @@ The body that is sent from the announcer is:
         "path": <full https endpoint>
       }
     ],
-    "name":"<service name> : <function name>",
+    "name": "<service name> : <function name>",
+    "identifier": <function name>,
     "events":[
       {<generated cloudformation event data>}
-    ]
+    ],
+    "contract": <your specified contract (if exists)>
   }  
 ]
 ```  
-### Kudos  
+## Kudos  
 Some methods are borrowed from the sourcecode of the [`serverless`](https://github.com/serverless/serverless) core plugins - super-duper-mega thanks  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ custom:
         /{function name}: <your contract> 
 ```     
 **Hook**:  
-The `hook` must be an accessible `POST` url accepting json input.
+The `hook` must be an accessible `POST` url accepting json input.   
 **Contract**:  
 The `contract` is an optional paramter. 
 If specified must be mapped to function name.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ custom:
 ```     
 **Hook**:  
 The `hook` must be an accessible `POST` url accepting json input.   
+    
 **Contract**:  
 The `contract` is an optional paramter. 
 If specified must be mapped to function name.

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const LambdaInfo = require('./lib/lambda-info');
 const AnnouncerException = require('./lib/announcer-exception');
 
 /* eslint-disable require-jsdoc */
+// TODO: write proper jsdoc
 class ServerlessPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -19,6 +20,53 @@ class ServerlessPlugin {
     };
   }
 
+  /**
+   * Handles the announcement of the service
+   * @return {Promise}
+   */
+  handle() {
+    const sls = this.serverless;
+    sls.cli.consoleLog('----- Lambda Announcer -----');
+
+    const announcer = this.resolveAnnouncerHook(this.service, sls);
+    const contract = this.resolveContractDefinition(this.service, sls);
+
+    if (!announcer.hook) {
+      sls.cli.log('!_Announcer hook is not specified correctly_!');
+      return;
+    }
+    return LambdaInfo
+      .getLambdaInfo(sls)
+
+      .then((info) => {
+        this.outputLambdaInfo(sls, info, announcer);
+        return (contract) ? this.mergeInfoAndContract(info, contract) : info;
+      })
+
+      .then((info) => {
+        return this.announce(announcer, info);
+      })
+
+      .then((result) => {
+        sls.cli.log(`Announcement result: ${result.statusCode}`);
+        return true;
+      })
+
+      .then((result) => {
+        sls.cli.consoleLog(`----- ----- ----- -----`);
+      })
+
+      .catch((error) => {
+        sls.cli.log(error);
+      });
+  }
+
+  /**
+   * Fires the hook specified in the announcer with the data passed as info
+   * @param {{hook: String}} announcer
+   * @param {Array} info
+   * @return {Promise}
+   */
   announce(announcer, info) {
     const options = {
       method: 'post',
@@ -39,7 +87,13 @@ class ServerlessPlugin {
     );
   }
 
-  resolveAnnouncerParameters(service, sls) {
+  /**
+   * Gathers the configuration of the announcer from serverless configuration
+   * @param {Object} service
+   * @param {Object} sls
+   * @return {Object}
+   */
+  getAnnouncerConfiguration(service, sls) {
     // service.custom is an array
     const announcers = service.custom
       // find the one settings defining the announcer
@@ -51,33 +105,74 @@ class ServerlessPlugin {
         .consoleLog('!_Number of found announcer settings is not one..._!');
       return {};
     }
+    return announcers.pop();
+  }
+
+  /**
+   * Returns the hook specified in the announcer
+   * @param {*} service
+   * @param {*} sls
+   * @return {{hook: String}}
+   */
+  resolveAnnouncerHook(service, sls) {
+    const announcer = this.getAnnouncerConfiguration(service, sls);
     return {
-      hook: announcers[0].hook || '',
+      hook: announcer.hook || '',
     };
   }
 
-  handle() {
-    const sls = this.serverless;
-    const announcer = this.resolveAnnouncerParameters(this.service, sls);
-    if (!announcer.hook) {
-      sls.cli.log('!_Announcer hook is not specified correctly_!');
-      return;
+  /**
+   * Returns the contract specification from the serverless config
+   * @param {*} service
+   * @param {*} sls
+   * @return {*}
+   */
+  resolveContractDefinition(service, sls) {
+    // Currently uses internal endpoint documentation approach.
+    const announcer = this.getAnnouncerConfiguration(service, sls);
+    if (announcer.contract) {
+      sls.cli.log('found contract');
+      sls.cli.consoleLog(announcer.contract);
+    } else {
+      sls.cli.log('no contract found');
     }
-    return LambdaInfo.getLambdaInfo(sls)
-      .then((info) => {
-        sls.cli.log('Gathered Lambda Info for functions:');
-        sls.cli.consoleLog(info.map((i) => {
-          return i.name;
-        }));
-        sls.cli.log(`Announcing to: ${announcer.hook}`);
-        return this.announce(announcer, info);
-      })
-      .then((result) => {
-        sls.cli.log(`Announcement result: ${result.statusCode}`);
-      })
-      .catch((error) => {
-        sls.cli.log(error);
-      });
+    return announcer.contract || {};
+  }
+
+  /**
+   * Merges the function information with related contract information (if any)
+   * @param {Array} info
+   * @param {*} contract
+   * @return {Array}
+   */
+  mergeInfoAndContract(info, contract) {
+    if (!contract) {
+      return info;
+    }
+    return info.map((i) => {
+      const functionContract = {contract: contract[`/${i.identifier}`]};
+
+      if (!functionContract.contract) {
+        // no matching contract found
+        return i;
+      } else {
+        return Object.assign(functionContract, i);
+      }
+    });
+  }
+
+  /**
+   * Prints the results of findings to the console.
+   * @param {*} sls
+   * @param {*} info
+   * @param {*} announcer
+   */
+  outputLambdaInfo(sls, info, announcer) {
+    sls.cli.log('Gathered Lambda Info for functions:');
+    sls.cli.consoleLog(info.map((i) => {
+      return i.name;
+    }));
+    sls.cli.log(`Announcing to: ${announcer.hook}`);
   }
 }
 


### PR DESCRIPTION
**What**
Enchanced the plugin with a feature to specify the contract of the endpoint. 
To do this add a `announcer.contract` property to the custom specifications.    

**How it works**
Inspired by RAML and OpenAPI, but do not pretend to follow the specifications 🗡 
In fact no structure is enforced but the `/<function name>`
Now possible to specify the contract like this: 
```
custom:
  - announcer:
      hook:                  <some url>
      contract:
        /example:          # matches the function name as `/<function name>`
          response:        #  free to follow any way of documenting actually
            body: 
              properties: 
                message:    string
```
**Yo.** 🖖 