### PR TITLE
fixed the forgotten changes in the lambda-info

### DIFF
--- a/lib/lambda-info.js
+++ b/lib/lambda-info.js
@@ -78,6 +78,7 @@ module.exports = {
         const func = {
           endpoints: [],
           name: `${serviceName} : ${f.name}`,
+          identifier: f.name,
           events: f.events,
         };
         func.endpoints = f.http.map((e) => {


### PR DESCRIPTION
Fix for the contract - I forgot to add the changes in the lambda-info script 🥁 
`identifier` is used to map to the contract, hence without this property the contracts can not be resolved... 
  
_Conclusion: I should really add testing._