### PR TITLE
Allow custom as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ plugins:
 ## Usage  
 ### Configuration
 In the `serverless.yml` specify a custom parameter for the announcer:  
-```
+```yaml
 custom:
-  - announcer:
-      # required:
-      hook: <your POST webhook>
-      # optional:
-      contract:   
-        /{function name}: <your contract> 
+  # can be specified as an array attribute too: - announcer:
+  announcer:
+    # required:
+    hook: <your POST webhook>
+    # optional:
+    contract:   
+      /{function name}: <your contract> 
 ```     
 **Hook**:  
 The `hook` must be an accessible `POST` url accepting json input.   

--- a/index.js
+++ b/index.js
@@ -94,8 +94,10 @@ class ServerlessPlugin {
    * @return {Object}
    */
   getAnnouncerConfiguration(service, sls) {
-    // service.custom is an array
-    const announcers = [service.custom.announcer] || service.custom
+    // service.custom can be an object or an array
+    const custom = service.custom;
+    const properties = custom.announcer ? [custom.announcer] : service.custom;
+    const announcers = properties
       // find the one settings defining the announcer
       .filter((s) => s.announcer)
       // map to only these settings to be on first level of depth

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ class ServerlessPlugin {
    */
   getAnnouncerConfiguration(service, sls) {
     // service.custom is an array
-    const announcers = service.custom
+    const announcers = [service.custom.announcer] || service.custom
       // find the one settings defining the announcer
       .filter((s) => s.announcer)
       // map to only these settings to be on first level of depth


### PR DESCRIPTION
**What**:
When using in a package that required another plugin encountered a problem   ⚡️

The properties for this plugin were listed as an array element: 
```yaml
custom:
  - announcer:
    ....
```
While the other plugin listed it's details as a property.

**Changes**:
Now the announcer properties are resolved from either an array or an attribute of the `custom` 